### PR TITLE
Make it work along with Spring

### DIFF
--- a/lib/bdd.rb
+++ b/lib/bdd.rb
@@ -1,12 +1,13 @@
 require "bdd/version"
+require "rspec/core"
 
 require "colorize"
 
 
 
-require "bdd/rspec" if defined? RSpec
-# TODO: require "bdd/test_unit" # if 
-# TODO: require "bdd/minitest"  # if 
+require "bdd/rspec"
+# TODO: require "bdd/test_unit" # if
+# TODO: require "bdd/minitest"  # if
 
 
 module Bdd


### PR DESCRIPTION
**Steps to reproduce**:
```
rails new blog -B -T
cd blog
echo "gem 'rspec-rails', '~> 3.0', group: :development" >> Gemfile
echo "gem 'rspec-rails', '~> 3.0', group: :test" >> Gemfile
echo "gem 'spring-commands-rspec', group: :development" >> Gemfile
echo "gem 'bdd', group: :test" >> Gemfile
bundle
rails generate rspec:install
bundle exec spring binstub rspec
```

Add the following spec to spec/test_spec.rb
```ruby
require 'spec_helper'

RSpec.describe "Math" do
  describe "+" do
    it "adds two numbers" do
      n = nil

      Given "n = 0" do
        n = 0
      end

      When "I assign n with result from 1 + 1" do
        n = 1 + 1
      end

      Then "n should be 2" do
        expect(n).to eq(2)
      end
    end
  end
end
```
**Output**
```
$ bin/rspec --format Bdd::RSpec::Formatter spec/test_spec.rb
/home/jivago/.rvm/gems/ruby-2.2.2/gems/bdd-0.0.3/lib/bdd/rspec.rb:3:in `<top (required)>': uninitialized constant RSpec::Core (NameError)
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bdd-0.0.3/lib/bdd.rb:7:in `require'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bdd-0.0.3/lib/bdd.rb:7:in `<top (required)>'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `require'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `each'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `block in require'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `each'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `require'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler.rb:134:in `require'
        from /home/jivago/code/blog/config/application.rb:16:in `<top (required)>'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application.rb:82:in `require'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application.rb:82:in `preload'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application.rb:143:in `serve'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application.rb:131:in `block in run'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application.rb:125:in `loop'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application.rb:125:in `run'
        from /home/jivago/.rvm/gems/ruby-2.2.2/gems/spring-1.3.6/lib/spring/application/boot.rb:18:in `<top (required)>'
        from /home/jivago/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /home/jivago/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from -e:1:in `<main>'
```
**Fixed** (using this fix)
```
$ bin/rspec --format Bdd::RSpec::Formatter spec/test_spec.rb 

Math
  +
    adds two numbers
       Given n = 0
        When I assign n with result from 1 + 1
        Then n should be 2

Finished in 0.00278 seconds (files took 0.12565 seconds to load)
1 example, 0 failures
```